### PR TITLE
firefox: add privacy defaults and document user.js behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
 # Config_files
 
 Public repo for configuration files.
+
+## Firefox `user.js`
+
+This Firefox profile keeps `network.cookie.cookieBehavior = 1` for day-to-day compatibility.
+
+It is intended to be used together with:
+- NoScript
+- Firefox Multi-Account Containers
+- the anti-fingerprinting and partitioning settings already enabled in `firefox/user.js`
+
+In this setup, privacy hardening does not rely on stricter cookie blocking alone, but on the combination of:
+- `privacy.resistFingerprinting`
+- `privacy.fingerprintingProtection`
+- Firefox internal partitioning / isolation preferences
+- container-based separation
+
+### Notes on breakage / expected behavior
+
+The profile intentionally blocks or restricts several browser capabilities.
+
+Blocked or denied by default:
+- camera
+- microphone
+- screen sharing
+- geolocation
+- desktop notifications
+- WebXR / XR APIs
+
+This can affect:
+- browser-based video calls
+- meeting tools that need mic or camera access
+- screen sharing from the browser
+- sites that request geolocation for maps or local results
+- sites that rely on push / desktop notifications
+- WebXR demos or browser VR / AR experiences
+
+Additional privacy-hardening prefs already present in `firefox/user.js` may also affect behavior:
+- `network.websocket.enabled = false` can impact some real-time web apps, chats, dashboards, terminals, collaborative tools, or similar live features
+- `media.navigator.streams.fake = true` can cause unusual behavior in some media-capability checks or websites expecting normal camera / microphone failure modes
+- DRM is disabled, so some protected streaming services may not work
+- WebGL is disabled, so some 3D or graphics-heavy websites may not work correctly
+
+This profile is intentionally opinionated and favors privacy / isolation over maximum website compatibility.

--- a/firefox/user.js
+++ b/firefox/user.js
@@ -154,6 +154,14 @@ user_pref("javascript.options.wasm.simd", false);
 user_pref("media.autoplay.default", 1);
 user_pref("privacy.trackingprotection.pbmode.enabled", true);
 user_pref("privacy.socialtracking.block", true);
+user_pref("browser.sessionstore.privacy_level", 2);
+user_pref("browser.send_pings", false);
+user_pref("permissions.default.camera", 2);
+user_pref("permissions.default.microphone", 2);
+user_pref("permissions.default.geo", 2);
+user_pref("permissions.default.screen", 2);
+user_pref("permissions.default.desktop-notification", 2);
+user_pref("permissions.default.xr", 2);
 
 // (your file had dom.allow_cut_copy commented out, leaving as-is)
 
@@ -257,6 +265,8 @@ user_pref("media.gmp-widevinecdm.enabled", false);                       // disa
  * SECTION: MISC PRIVACY
 ****************************************************************************/
 user_pref("beacon.enabled", false);                                      // block navigator.sendBeacon()
+user_pref("dom.private-attribution.submission.enabled", false);
+user_pref("dom.private-attribution.reporting.enabled", false);
 
 user_pref("layout.css.font-visibility", 1);  // "base" fonts only
 user_pref("security.ssl.require_safe_negotiation", true);


### PR DESCRIPTION
## Summary
- add the agreed privacy and permission defaults to `firefox/user.js`
- document how this Firefox profile is intended to be used
- document the expected compatibility tradeoffs in `README.md`

## Added prefs
- `browser.send_pings = false`
- `browser.sessionstore.privacy_level = 2`
- `permissions.default.camera = 2`
- `permissions.default.microphone = 2`
- `permissions.default.geo = 2`
- `permissions.default.screen = 2`
- `permissions.default.desktop-notification = 2`
- `permissions.default.xr = 2`
- `dom.private-attribution.submission.enabled = false`
- `dom.private-attribution.reporting.enabled = false`

## Notes
- `network.http.referer.disallowCrossSiteRelaxingDefault = true` is intentionally left out for now because it is still under discussion
- `network.websocket.enabled = false` and `media.navigator.streams.fake = true` are kept as-is, but the README now documents the kind of behavior they may affect
- the README also clarifies that `network.cookie.cookieBehavior = 1` is kept for day-to-day compatibility and that this profile is intended to be used together with NoScript, Firefox Multi-Account Containers, and Firefox internal partitioning / anti-fingerprinting settings