### PR TITLE
repo: fix wallpaper rotation and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,47 @@
 # Config_files
 
-Public repo for configuration files.
+Public repo for configuration files used directly and also consumed by `myshell` through its `config_files` profile.
+
+## Contents
+
+### Firefox
+- `firefox/user.js`
+- privacy-focused Firefox profile defaults and notes about expected compatibility tradeoffs
+
+Target location:
+- Firefox profile directory: `~/.mozilla/firefox/<profile>/user.js`
+
+### Home dotfiles
+- `home/.vimrc`
+- `home/.tmux.conf`
+- `home/.inputrc`
+- `home/.gitconfig`
+- `home/.alacritty.toml`
+
+Target locations:
+- `~/.vimrc`
+- `~/.tmux.conf`
+- `~/.inputrc`
+- `~/.gitconfig`
+- `~/.alacritty.toml`
+
+### Hyprland
+- `hyprland/hyprland.conf`
+- `hyprland/wallpaper/wallpaper-rotation.sh`
+
+Expected locations depend on your setup. This repository stores the source files, but deployment / copy / symlink strategy may be handled externally.
+
+### WSL
+- `wsl/.wslconfig`
+
+Target location:
+- Windows user profile: `%UserProfile%\.wslconfig`
+
+## Integration with `myshell`
+
+This repository is also consumed by `myshell` through the `config_files` profile. In that model, `myshell` is the bootstrap / installer side, while this repository acts as the source of truth for the configuration files.
+
+That means portability matters here: unnecessary machine-specific assumptions in these files can affect `myshell` installs too.
 
 ## Firefox `user.js`
 
@@ -44,3 +85,7 @@ Additional privacy-hardening prefs already present in `firefox/user.js` may also
 - WebGL is disabled, so some 3D or graphics-heavy websites may not work correctly
 
 This profile is intentionally opinionated and favors privacy / isolation over maximum website compatibility.
+
+## Notes on machine-specific config
+
+Some files in this repository may still contain personal or environment-specific paths. Where that happens, they should be treated as custom config, and ideally cleaned up over time if they are expected to be reused through `myshell` or on other machines.

--- a/hyprland/wallpaper/wallpaper-rotation.sh
+++ b/hyprland/wallpaper/wallpaper-rotation.sh
@@ -6,7 +6,7 @@ MONITORS=("DP-6" "HDMI-A-2")
 
 while true; do
   # Pick a random wallpaper (image or video)
-  FILE=$(find "$WALLPAPER_DIR" -maxdepth 1 -type f \( -iname '*.jpg' -o -iname '*.png' -o -iname '*.jpeg' \) | shuf -n 1)
+  FILE=$(find "$WALLPAPER_DIR" -maxdepth 1 -type f \( -iname '*.jpg' -o -iname '*.png' -o -iname '*.jpeg' -o -iname '*.mp4' \) | shuf -n 1)
 
   # Kill any running mpvpaper instance (for video wallpapers)
   pkill mpvpaper


### PR DESCRIPTION
## Summary
- fix the wallpaper rotation script so video wallpapers can actually be selected
- expand the README with repo structure, expected target locations, and `myshell` integration context
- document that this repo is also used as a source by `myshell`, so portability matters here too

## Changes
- `hyprland/wallpaper/wallpaper-rotation.sh`
  - include `*.mp4` in the wallpaper file selection logic so the existing video branch can be reached
- `README.md`
  - add repo contents overview
  - add expected target locations for Firefox, home dotfiles, Hyprland, and WSL
  - add notes about `myshell` consuming this repo through its `config_files` profile
  - keep the Firefox `user.js` compatibility notes and make the repo purpose clearer

## Notes
- this PR does not yet clean up all machine-specific paths in Hyprland-related files
- that follow-up is better done with the `myshell` integration context already in mind