### PR TITLE
hyprland: document local references and use portable home paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ Target locations:
 
 Expected locations depend on your setup. This repository stores the source files, but deployment / copy / symlink strategy may be handled externally.
 
+Recommended paths when deploying locally:
+- `~/.config/hypr/hyprland.conf`
+- `~/.config/hypr/wallpaper/wallpaper-rotation.sh`
+
+Hyprland notes:
+- monitor definitions are reference values and may need local adjustment
+- external programs such as IDE, browser, launcher/menu, and file manager are not a `myshell` integration contract; they are reference values and can be changed or removed locally
+- screenshot output paths are local preference
+- keyboard layout and other input preferences are local preference
+- optional local scripts such as NVIDIA fan control may exist outside this repo and may be managed separately
+
 ### WSL
 - `wsl/.wslconfig`
 

--- a/hyprland/hyprland.conf
+++ b/hyprland/hyprland.conf
@@ -26,6 +26,7 @@ exec = gsettings set org.desktop.gnome.interface color-scheme "prefer-dark"
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
+# Monitor definitions are environment-specific reference values and may need local adjustment.
 
 # ASUS on DP-6, primary, scale 1
 monitor=DP-6, preferred, 0x0, 1
@@ -39,6 +40,8 @@ monitor=HDMI-A-2, 1600x900@60, 2560x0, 1
 ###################
 
 # See https://wiki.hyprland.org/Configuring/Keywords/
+# External programs below are not integrated by myshell. Treat them as reference values
+# and adjust or remove them according to the local machine.
 
 # Set programs that you use
 $terminal = kitty
@@ -190,6 +193,7 @@ misc {
 #############
 
 # https://wiki.hyprland.org/Configuring/Variables/#input
+# Input values below are reference values and may need local adjustment.
 input {
     kb_layout = es
     kb_variant =
@@ -228,6 +232,7 @@ $mainMod = SUPER # Sets "Windows" key as main modifier
 # Open programs
 bind = $mainMod, 1, exec, $ide
 bind = $mainMod, 2, exec, $browser
+# Screenshot output path below is a local preference and may be adjusted.
 bind = SUPER_SHIFT, S, exec, grim -g "$(slurp)" ~/Pictures/screenshot_$(date +%s).png
 
 # Window switching with Alt + TAB
@@ -292,11 +297,12 @@ bindl = , XF86AudioMute, exec, env XDG_RUNTIME_DIR=/run/user/1000 /usr/bin/pactl
 ##############################
 
 # NVIDIA FAN
-exec-once = /home/sergio/Documents/doc/z_linux/nvidia/nvidiafan.sh
+# Optional local script. If managed externally, keep it under $HOME and adjust as needed.
+exec-once = $HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh
 
 # THEMES
 #source=~/.config/hypr/themes/cyber/theme.conf
 # sudo pacman -S mpvpaper hyprpaper
-exec-once = /bin/bash -c "nohup /home/sergio/.config/hypr/wallpaper-rotation.sh >/dev/null 2>&1 &"
+exec-once = /bin/bash -c "nohup $HOME/.config/hypr/wallpaper/wallpaper-rotation.sh >/dev/null 2>&1 &"
 
 


### PR DESCRIPTION
## Summary
- make Hyprland home-directory paths more portable
- document which Hyprland values are local reference values rather than a `myshell` integration contract
- expand the README with Hyprland-specific deployment and customization notes

## Changes
- `hyprland/hyprland.conf`
  - change the wallpaper rotation script path to use `$HOME/.config/hypr/wallpaper/wallpaper-rotation.sh`
  - change the NVIDIA fan script path to use `$HOME/...` instead of `/home/sergio/...`
  - add comments clarifying that monitors, external programs, input preferences, and screenshot paths are local reference values that may need adjustment
- `README.md`
  - add recommended Hyprland target paths
  - document that external programs in the Hyprland config are examples / reference values, not part of a `myshell` integration contract
  - document that monitor, input, screenshot, and optional local script values may need machine-specific adjustment

## Notes
- this PR does not yet change how `myshell` deploys Hyprland-related files
- the NVIDIA fan script is still treated as an optional local script managed outside this repo; a follow-up in `myshell` may still be needed depending on how you want to deploy it