### PR TITLE
services: add NVIDIA fan user service definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,23 @@ Hyprland notes:
 - keyboard layout and other input preferences are local preference
 - optional local scripts such as NVIDIA fan control may exist outside this repo and may be managed separately
 - wallpaper rotation can also be deployed as a user service instead of being launched from `hyprland.conf`
+- NVIDIA fan control can also be deployed as a user service instead of being launched from `hyprland.conf`
 
 ### Services
 - `services/hyprland/hypr-wallpaper.service`
 - `services/hyprland/wallpaper-rotation.sh`
+- `services/nvidia/nvidia-fan.service`
 
 Recommended paths when deploying locally:
 - `~/.config/systemd/user/hypr-wallpaper.service`
-- consumer repos may keep the script in a repo-managed path and rewrite the unit accordingly
+- `~/.config/systemd/user/nvidia-fan.service`
+- consumer repos may keep scripts in repo-managed paths and rewrite the unit accordingly
 
 Service notes:
 - `hypr-wallpaper.service` is a user service intended to run wallpaper rotation independently from shell startup
-- consumer repos such as `myshell` may rewrite or template the service unit so `ExecStart` points to a repo-managed path based on their own install logic
+- `nvidia-fan.service` is a user service definition for NVIDIA fan control
+- the NVIDIA fan script itself is still treated as external/local in this repo and is not yet versioned here
+- consumer repos such as `myshell` may rewrite or template service units so `ExecStart` points to a repo-managed path based on their own install logic
 
 ### WSL
 - `wsl/.wslconfig`

--- a/hyprland/hyprland.conf
+++ b/hyprland/hyprland.conf
@@ -297,8 +297,7 @@ bindl = , XF86AudioMute, exec, env XDG_RUNTIME_DIR=/run/user/1000 /usr/bin/pactl
 ##############################
 
 # NVIDIA FAN
-# Optional local script. If managed externally, keep it under $HOME and adjust as needed.
-exec-once = $HOME/Documents/doc/z_linux/nvidia/nvidiafan.sh
+# NVIDIA fan control is expected to be managed by a user service when deployed that way.
 
 # THEMES
 #source=~/.config/hypr/themes/cyber/theme.conf

--- a/services/nvidia/nvidia-fan.service
+++ b/services/nvidia/nvidia-fan.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NVIDIA fan control service
+After=graphical-session.target
+Wants=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=%h/Documents/doc/z_linux/nvidia/nvidiafan.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add a user service definition for NVIDIA fan control
- update `hyprland.conf` to stop launching NVIDIA fan control directly
- document the new service in the root README

## Changes
- `services/nvidia/nvidia-fan.service`
  - add a user service definition for NVIDIA fan control
- `hyprland/hyprland.conf`
  - remove direct NVIDIA fan startup and leave a note that it is expected to be managed by a user service when deployed that way
- `README.md`
  - document `nvidia-fan.service` in the `services/` section
  - clarify that the NVIDIA fan script is still treated as external/local and is not yet versioned in this repo

## Notes
- this PR intentionally mirrors the service-oriented approach used for Hyprland wallpaper where possible
- unlike wallpaper rotation, the NVIDIA fan script itself is not yet part of `config_files`, so this PR only adds the service definition and documentation
- a follow-up in `myshell` can now install / rewrite / enable this user service with the same activation pattern used for other services