### PR TITLE
tmux: remove conflicting legacy mouse toggles

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -5,6 +5,7 @@
 #GETTING STARTED - https://github.com/tmux/tmux/wiki/Getting-Started
 # mkdir -p ~/.vim/colors
 # wget https://raw.githubusercontent.com/altercation/vim-colors-solarized/master/colors/solarized.vim -O ~/.vim/colors/solarized.vim
+# Enable mouse support for modern tmux versions.
 set -g mouse on
 #
 # https://github.com/seebi/tmux-colors-solarized/blob/master/tmuxcolors-256.conf
@@ -106,9 +107,7 @@ if-shell '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -lt 4\) -o #
 # status bar
 if-shell '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -lt 2\) -o #{$TMUX_VERSION_MAJOR} -le 1' 'set-option -g status-utf8 on'
 
-# rm mouse mode fail
-if-shell '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -ge 1\)' 'set -g mouse off'
-if-shell '\( #{$TMUX_VERSION_MAJOR} -eq 2 -a #{$TMUX_VERSION_MINOR} -lt 1\) -o #{$TMUX_VERSION_MAJOR} -le 1' 'set -g mode-mouse off'
+# Legacy mouse-mode toggles removed: this config uses mouse support for modern tmux.
 
 # fix pane_current_path on new window and splits
 if-shell "test '#{$TMUX_VERSION_MAJOR} -gt 1 -o \( #{$TMUX_VERSION_MAJOR} -eq 1 -a #{$TMUX_VERSION_MINOR} -ge 8 \)'" 'unbind c; bind c new-window -c "#{pane_current_path}"'


### PR DESCRIPTION
## Summary
- keep mouse support enabled consistently in `.tmux.conf`
- remove the legacy compatibility block that disabled mouse mode again
- leave a short note explaining the cleanup

## Why
The config enabled mouse support near the top with `set -g mouse on`, but later disabled mouse again for tmux 2.1+ through a legacy compatibility block. That made the effective behavior confusing and contradictory.

## Changes
- keep `set -g mouse on`
- remove the old `if-shell` mouse-off / mode-mouse-off compatibility lines
- add a short comment clarifying that this config now targets modern tmux mouse behavior

## Notes
- this PR is intentionally small and only resolves the contradiction around mouse behavior
- no broader tmux style or keybinding changes are included here