### PR TITLE
hyprland: add minimal hyprpaper config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Target locations:
 
 ### Hyprland
 - `hyprland/hyprland.conf`
+- `hyprland/hyprpaper.conf`
 
 Expected locations depend on your setup. This repository stores the source files, but deployment / copy / symlink strategy may be handled externally.
 
 Recommended paths when deploying locally:
 - `~/.config/hypr/hyprland.conf`
+- `~/.config/hypr/hyprpaper.conf`
 
 Hyprland notes:
 - monitor definitions are reference values and may need local adjustment
@@ -39,6 +41,7 @@ Hyprland notes:
 - screenshot output paths are local preference
 - keyboard layout and other input preferences are local preference
 - optional local scripts such as NVIDIA fan control may exist outside this repo and may be managed separately
+- `hyprpaper.conf` is intentionally minimal so `hyprpaper` can start with a valid config; wallpaper selection is handled by the rotation script/service
 - wallpaper rotation can also be deployed as a user service instead of being launched from `hyprland.conf`
 - NVIDIA fan control can also be deployed as a user service instead of being launched from `hyprland.conf`
 

--- a/hyprland/hyprpaper.conf
+++ b/hyprland/hyprpaper.conf
@@ -1,0 +1,2 @@
+# Intentionally minimal.
+# hyprpaper only needs a valid config file to start; wallpaper selection is handled by the rotation script/service.


### PR DESCRIPTION
## Summary
- add a minimal valid `hyprpaper.conf`
- document why it is intentionally minimal
- document the local deployment path in the root README

## Changes
- `hyprland/hyprpaper.conf`
  - add a minimal valid config file with a short comment explaining why it is intentionally empty/minimal
- `README.md`
  - document `hyprland/hyprpaper.conf` in the Hyprland section
  - add the expected local path
  - explain that wallpaper selection is handled by the rotation script/service, while `hyprpaper.conf` only exists so `hyprpaper` can start with a valid config

## Notes
- this PR does not yet change the wallpaper rotation script defaults
- `WALLPAPER_DIR` and `INTERVAL` are still local runtime values and can be adjusted independently