### PR TITLE
services: delay nvidia fan startup until session is ready

### DIFF
--- a/services/nvidia/nvidia-fan.service
+++ b/services/nvidia/nvidia-fan.service
@@ -5,6 +5,7 @@ Wants=graphical-session.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 10
 ExecStart=%h/Documents/doc/z_linux/nvidia/nvidiafan.sh
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Summary
- add a short startup delay to `nvidia-fan.service`
- avoid the initial login-time failure seen before the graphical session was fully ready

## Changes
- `services/nvidia/nvidia-fan.service`
  - add `ExecStartPre=/bin/sleep 10`

## Why
On cold login / reboot, `nvidia-fan.service` could fail on its first start even though the script and commands worked fine once the session was fully up. A short pre-start delay fixes that race and was validated after reboot.

## Notes
- this PR is intentionally minimal and only addresses startup timing
- documentation for dependencies can be added later in a separate PR