### PR TITLE
services: version nvidia fan script in config_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Recommended paths when deploying locally:
 Service notes:
 - `hypr-wallpaper.service` is a user service intended to run wallpaper rotation independently from shell startup
 - `nvidia-fan.service` is a user service definition for NVIDIA fan control
-- both service scripts are now versioned in this repo and can be deployed by consumer repos such as `myshell`
+- both service scripts are versioned in this repo and can be deployed by consumer repos such as `myshell`
 
 #### Service prerequisites
 
@@ -76,7 +76,7 @@ Service notes:
 - `nvidia-settings`
 - `sudo`
 - `xhost`
-- the local script path used by deployment must match the service `ExecStart`
+- the deployed script path must match the service `ExecStart` path
 - `sudo` for `nvidia-settings` must work non-interactively in the user-session context
 - the service depends on the graphical session being ready; a startup delay is used to avoid race conditions at login
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Hyprland notes:
 - external programs such as IDE, browser, launcher/menu, and file manager are not a `myshell` integration contract; they are reference values and can be changed or removed locally
 - screenshot output paths are local preference
 - keyboard layout and other input preferences are local preference
-- optional local scripts such as NVIDIA fan control may exist outside this repo and may be managed separately
 - `hyprpaper.conf` is intentionally minimal so `hyprpaper` can start with a valid config; wallpaper selection is handled by the rotation script/service
 - wallpaper rotation can also be deployed as a user service instead of being launched from `hyprland.conf`
 - NVIDIA fan control can also be deployed as a user service instead of being launched from `hyprland.conf`
@@ -49,17 +48,18 @@ Hyprland notes:
 - `services/hyprland/hypr-wallpaper.service`
 - `services/hyprland/wallpaper-rotation.sh`
 - `services/nvidia/nvidia-fan.service`
+- `services/nvidia/nvidiafan.sh`
 
 Recommended paths when deploying locally:
 - `~/.config/systemd/user/hypr-wallpaper.service`
 - `~/.config/systemd/user/nvidia-fan.service`
-- consumer repos may keep scripts in repo-managed paths and rewrite the unit accordingly
+- `~/.config/hypr/wallpaper-rotation.sh`
+- `~/.config/nvidia/nvidiafan.sh`
 
 Service notes:
 - `hypr-wallpaper.service` is a user service intended to run wallpaper rotation independently from shell startup
 - `nvidia-fan.service` is a user service definition for NVIDIA fan control
-- the NVIDIA fan script itself is still treated as external/local in this repo and is not yet versioned here
-- consumer repos such as `myshell` may rewrite or template service units so `ExecStart` points to a repo-managed path based on their own install logic
+- both service scripts are now versioned in this repo and can be deployed by consumer repos such as `myshell`
 
 #### Service prerequisites
 
@@ -76,7 +76,7 @@ Service notes:
 - `nvidia-settings`
 - `sudo`
 - `xhost`
-- a local NVIDIA fan script available at the expected path
+- the local script path used by deployment must match the service `ExecStart`
 - `sudo` for `nvidia-settings` must work non-interactively in the user-session context
 - the service depends on the graphical session being ready; a startup delay is used to avoid race conditions at login
 

--- a/services/nvidia/nvidia-fan.service
+++ b/services/nvidia/nvidia-fan.service
@@ -6,7 +6,7 @@ Wants=graphical-session.target
 [Service]
 Type=simple
 ExecStartPre=/bin/sleep 10
-ExecStart=%h/Documents/doc/z_linux/nvidia/nvidiafan.sh
+ExecStart=%h/.config/nvidia/nvidiafan.sh
 Restart=on-failure
 RestartSec=5
 

--- a/services/nvidia/nvidiafan.sh
+++ b/services/nvidia/nvidiafan.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+interval=20  # Time between each temperature check (in seconds)
+
+setfan() {
+  {
+    xhost si:localuser:root
+    sudo /usr/bin/nvidia-settings -a "[gpu:0]/GPUFanControlState=1" \
+                                  -a "[fan:0]/GPUTargetFanSpeed=$1" \
+                                  -a "[fan:1]/GPUTargetFanSpeed=$1"
+    xhost -si:localuser:root
+  } > /dev/null
+}
+
+for(( ; ; ))
+do
+  # Get the current GPU temperature
+  temp=$(nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader)
+
+  # Set fan speed based on temperature ranges
+  if (( temp <= 30 ))
+  then
+      fan_speed=30
+  elif (( temp > 30 && temp <= 40 ))
+  then
+      fan_speed=40
+  elif (( temp > 40 && temp <= 50 ))
+  then
+      fan_speed=50
+  elif (( temp > 50 && temp <= 60 ))
+  then
+      fan_speed=60
+  elif (( temp > 60 && temp <= 70 ))
+  then
+      fan_speed=70
+  elif (( temp > 70 && temp <= 80 ))
+  then
+      fan_speed=80
+  elif (( temp > 80 && temp <= 90 ))
+  then
+      fan_speed=90
+  else
+      fan_speed=100
+  fi
+
+  # Set the fan speed
+  setfan "$fan_speed"
+
+  # Sleep for the defined interval
+  sleep "$interval"
+done


### PR DESCRIPTION
## Summary
- add `nvidiafan.sh` to `config_files`
- treat it like the wallpaper rotation script: versioned in the repo and ready to be deployed by consumer repos
- update README so it no longer describes the NVIDIA fan script as external-only

## Changes
- `services/nvidia/nvidiafan.sh`
  - add the current NVIDIA fan control script
- `README.md`
  - list `services/nvidia/nvidiafan.sh`
  - add the expected deployed path
  - update notes to reflect that both service scripts are now versioned in this repo
  - adjust prerequisites wording so the deployed script path must match the service definition

## Notes
- this PR does not yet change `myshell`
- the next follow-up is to update `myshell` so `.nvidia-fan` downloads the script to its final local path, mirroring `.hyprland-wallpaper`