### PR TITLE
hyprland/waybar: read GPU temperature from nvidia-smi

### DIFF
--- a/hyprland/waybar/hardware.sh
+++ b/hyprland/waybar/hardware.sh
@@ -3,11 +3,8 @@
 # CPU temp
 cpu_temp=$(sensors | awk '/k10temp-pci-00c3/,/^$/ { if ($1 == "Tctl:") print $2 }' | sed 's/+//;s/°C//')
 
-# Since you have AMD GPU, disable nvidia-smi or remove it (replace with amdgpu temp)
-# For now, let's get GPU temp from amdgpu:
-gpu_temp=$(sensors | awk '/amdgpu-pci-1000/,/^$/ { if ($1 == "edge:") print $2 }' | sed 's/+//;s/°C//')
-
-# NVIDIA GPU fan speed in percent using nvidia-smi
+# NVIDIA GPU temperature and fan speed using nvidia-smi
+gpu_temp=$(nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader,nounits 2>/dev/null || echo "N/A")
 fan_speed=$(nvidia-smi --query-gpu=fan.speed --format=csv,noheader,nounits 2>/dev/null || echo "N/A")
 
 # CPU usage percentage


### PR DESCRIPTION
## Summary
- make Waybar read NVIDIA GPU temperature from `nvidia-smi`
- keep GPU fan speed sourced from `nvidia-smi` as before
- stop mixing AMD temperature with NVIDIA fan speed in the same module

## Changes
- `hyprland/waybar/hardware.sh`
  - replace the AMD `sensors`-based GPU temperature line with an NVIDIA `nvidia-smi` query
  - update the nearby comment so it matches the real data source

## Why
The current script shows GPU temperature from `amdgpu` but GPU fan speed from NVIDIA. That makes the Waybar output misleading when the active values being tracked are for the NVIDIA card.

## Notes
- this is a minimal, targeted fix
- CPU temperature, CPU usage, and RAM reporting are unchanged