### PR TITLE
firefox: tune performance without relaxing privacy model

### DIFF
--- a/firefox/user.js
+++ b/firefox/user.js
@@ -2,38 +2,39 @@
  * SECTION: GENERAL                                                        *
 ****************************************************************************/
 user_pref("content.notify.interval", 100000);
+user_pref("browser.sessionstore.interval", 60000);
 
 /****************************************************************************
  * SECTION: GFX                                                            *
 ****************************************************************************/
-user_pref("gfx.canvas.accelerated.cache-size", 512);
-user_pref("gfx.content.skia-font-cache-size", 20);
+user_pref("gfx.canvas.accelerated.cache-size", 1024);
+user_pref("gfx.content.skia-font-cache-size", 80);
 user_pref("browser.tabs.hoverPreview.enabled", false);
 user_pref("browser.tabs.hoverPreview.showThumbnails", false);
 
 /****************************************************************************
  * SECTION: DISK CACHE                                                     *
 ****************************************************************************/
-user_pref("browser.cache.disk.enable", false);
+user_pref("browser.cache.disk.enable", true);
 
 /****************************************************************************
  * SECTION: MEDIA CACHE                                                    *
 ****************************************************************************/
-user_pref("media.memory_cache_max_size", 65536);
-user_pref("media.cache_readahead_limit", 7200);
-user_pref("media.cache_resume_threshold", 3600);
+user_pref("media.memory_cache_max_size", 131072);
+user_pref("media.cache_readahead_limit", 14400);
+user_pref("media.cache_resume_threshold", 7200);
 
 /****************************************************************************
  * SECTION: IMAGE CACHE                                                    *
 ****************************************************************************/
-user_pref("image.mem.decode_bytes_at_a_time", 32768);
+user_pref("image.mem.decode_bytes_at_a_time", 65536);
 
 /****************************************************************************
  * SECTION: NETWORK                                                         *
 ****************************************************************************/
-user_pref("network.http.max-connections", 256);
+user_pref("network.http.max-connections", 512);
 
-user_pref("network.http.max-persistent-connections-per-server", 6);
+user_pref("network.http.max-persistent-connections-per-server", 10);
 
 user_pref("network.http.max-urgent-start-excessive-connections-per-host", 5);
 user_pref("network.http.pacing.requests.enabled", false);


### PR DESCRIPTION
## Summary
- improve Firefox runtime fluency without relaxing the privacy model already in place
- keep the current privacy/network/fingerprinting posture intact
- tune caches, session write frequency, and conservative connection limits

## Changes
- `firefox/user.js`
  - set `browser.sessionstore.interval = 60000`
  - increase `gfx.canvas.accelerated.cache-size` to `1024`
  - increase `gfx.content.skia-font-cache-size` to `80`
  - enable `browser.cache.disk.enable`
  - increase `media.memory_cache_max_size` to `131072`
  - increase `media.cache_readahead_limit` to `14400`
  - increase `media.cache_resume_threshold` to `7200`
  - increase `image.mem.decode_bytes_at_a_time` to `65536`
  - increase `network.http.max-connections` to `512`
  - increase `network.http.max-persistent-connections-per-server` to `10`

## Why
The current profile preserves privacy well, but it can feel slower than desired in day-to-day browsing. These changes focus on runtime smoothness by improving caches, media buffering, and conservative connection limits, while leaving the privacy-heavy parts of the profile unchanged.

## Notes
- this PR intentionally does **not** relax:
  - `privacy.resistFingerprinting`
  - `privacy.fingerprintingProtection`
  - `privacy.firstparty.isolate`
  - `privacy.partition.*`
  - `network.trr.*`
  - `network.dns.disablePrefetch*`
  - `network.predictor.*`
  - `network.websocket.enabled`
  - `webgl.disabled`
- disk cache is re-enabled here because it improves real-world browsing smoothness without changing the browser's privacy model on the network/fingerprinting side