### PR TITLE
services: make hypr wallpaper recover hyprpaper

### DIFF
--- a/services/hyprland/wallpaper-rotation.sh
+++ b/services/hyprland/wallpaper-rotation.sh
@@ -4,15 +4,44 @@ WALLPAPER_DIR="/usr/share/hypr"
 INTERVAL=600  # 10 minutes
 MONITORS=("DP-6" "HDMI-A-2")
 
+start_hyprpaper() {
+  echo "[script] Starting hyprpaper..."
+  hyprpaper >/dev/null 2>&1 &
+  sleep 1
+}
+
+ensure_hyprpaper() {
+  if ! pgrep -x hyprpaper >/dev/null; then
+    start_hyprpaper
+  fi
+}
+
 while true; do
+  ensure_hyprpaper
+
   # Pick a random wallpaper (image or video)
   FILE=$(find "$WALLPAPER_DIR" -maxdepth 1 -type f \( -iname '*.jpg' -o -iname '*.png' -o -iname '*.jpeg' -o -iname '*.mp4' \) | shuf -n 1)
 
-  # Kill any running mpvpaper instance (for video wallpapers)
-  pkill mpvpaper
+  if [ -z "$FILE" ]; then
+    echo "[error] No wallpapers found in $WALLPAPER_DIR"
+    sleep "$INTERVAL"
+    continue
+  fi
 
-  # Unload all current hyprpaper wallpapers
-  hyprctl hyprpaper unload all
+  # Kill any running mpvpaper instance (for video wallpapers)
+  pkill mpvpaper 2>/dev/null
+
+  # Unload all current hyprpaper wallpapers; if hyprpaper is not responding, restart it once
+  if ! hyprctl hyprpaper unload all >/dev/null 2>&1; then
+    echo "[script] hyprpaper not responding, restarting..."
+    pkill hyprpaper 2>/dev/null
+    start_hyprpaper
+    if ! hyprctl hyprpaper unload all >/dev/null 2>&1; then
+      echo "[error] hyprpaper still not responding after restart."
+      sleep "$INTERVAL"
+      continue
+    fi
+  fi
 
   if [[ "$FILE" == *.mp4 ]]; then
     echo "[mpvpaper] Setting video wallpaper: $FILE"
@@ -21,12 +50,21 @@ while true; do
     done
   else
     echo "[hyprpaper] Setting static wallpaper: $FILE"
-    # preload once before loop to avoid redundant preload calls
-    hyprctl hyprpaper preload "$FILE"
+    if ! hyprctl hyprpaper preload "$FILE" >/dev/null 2>&1; then
+      echo "[script] preload failed, restarting hyprpaper..."
+      pkill hyprpaper 2>/dev/null
+      start_hyprpaper
+      if ! hyprctl hyprpaper preload "$FILE" >/dev/null 2>&1; then
+        echo "[error] Failed to preload wallpaper after restart: $FILE"
+        sleep "$INTERVAL"
+        continue
+      fi
+    fi
+
     for MON in "${MONITORS[@]}"; do
-      hyprctl hyprpaper wallpaper "$MON,$FILE"
+      hyprctl hyprpaper wallpaper "$MON,$FILE" >/dev/null 2>&1
     done
   fi
 
-  sleep $INTERVAL
+  sleep "$INTERVAL"
 done


### PR DESCRIPTION
## Summary
- make `wallpaper-rotation.sh` recover when `hyprpaper` is missing or stops responding
- avoid the current state where the systemd user service stays alive but wallpaper changes silently fail
- keep the change minimal and focused on hyprpaper recovery

## Changes
- `services/hyprland/wallpaper-rotation.sh`
  - add `start_hyprpaper()`
  - add `ensure_hyprpaper()`
  - start `hyprpaper` if it is not running
  - restart `hyprpaper` once if `hyprctl hyprpaper unload all` fails
  - restart `hyprpaper` once if `hyprctl hyprpaper preload` fails
  - skip the current iteration cleanly if recovery still fails
  - add a guard for an empty wallpaper selection

## Why
The current script assumes `hyprpaper` is available forever. In practice, the user service can remain active while `hyprpaper` is gone or unresponsive, which leaves wallpaper rotation effectively broken even though the service still looks healthy in `systemctl --user status`.

## Notes
- this PR does not change the interval, monitor list, or wallpaper selection logic
- it only improves resiliency around `hyprpaper`
- further tuning may still be needed if `hyprpaper` itself is failing for environment reasons outside the script