### PR TITLE
firefox: rebalance privacy defaults for daily-use performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,28 @@ It is intended to be used together with:
 - the anti-fingerprinting and partitioning settings already enabled in `firefox/user.js`
 
 In this setup, privacy hardening does not rely on stricter cookie blocking alone, but on the combination of:
-- `privacy.resistFingerprinting`
 - `privacy.fingerprintingProtection`
-- Firefox internal partitioning / isolation preferences
+- Firefox internal partitioning preferences
 - container-based separation
+
+### Daily-use balance
+
+The profile is intentionally privacy-focused, but it is also intended to remain usable as a primary browser profile.
+
+For that reason, the current baseline avoids some of the heaviest compatibility / performance tradeoffs for daily browsing:
+- `privacy.resistFingerprinting` is disabled
+- `privacy.firstparty.isolate` is disabled
+- `network.websocket.enabled` is enabled
+- `webgl.disabled` is disabled
+
+The remaining baseline still keeps:
+- strict content blocking
+- container support
+- fingerprinting protection
+- partitioned network / service-worker / third-party storage
+- HTTPS-only mode
+- blocked-by-default camera / microphone / geolocation / screen / desktop notification / XR permissions
+- telemetry and studies disabled
 
 ### Notes on breakage / expected behavior
 
@@ -115,12 +133,10 @@ This can affect:
 - WebXR demos or browser VR / AR experiences
 
 Additional privacy-hardening prefs already present in `firefox/user.js` may also affect behavior:
-- `network.websocket.enabled = false` can impact some real-time web apps, chats, dashboards, terminals, collaborative tools, or similar live features
 - `media.navigator.streams.fake = true` can cause unusual behavior in some media-capability checks or websites expecting normal camera / microphone failure modes
 - DRM is disabled, so some protected streaming services may not work
-- WebGL is disabled, so some 3D or graphics-heavy websites may not work correctly
 
-This profile is intentionally opinionated and favors privacy / isolation over maximum website compatibility.
+This profile is intentionally opinionated and favors privacy / isolation, while aiming to avoid the most noticeable daily-use performance regressions for modern web apps.
 
 ## Notes on machine-specific config
 

--- a/firefox/user.js
+++ b/firefox/user.js
@@ -149,7 +149,7 @@ user_pref("privacy.userContext.ui.enabled", true);
 user_pref("security.app_menu.recordEventTelemetry", false);
 user_pref("network.cookie.cookieBehavior", 1);
 user_pref("privacy.trackingprotection.enabled", true);
-user_pref("privacy.resistFingerprinting", true);
+user_pref("privacy.resistFingerprinting", false);
 user_pref("geo.enabled", false);
 user_pref("javascript.options.wasm.simd", false);
 user_pref("media.autoplay.default", 1);
@@ -176,7 +176,7 @@ user_pref("media.navigator.enabled", false);
 user_pref("security.certerrors.recordEventTelemetry", false);
 user_pref("security.protectionspopup.recordEventTelemetry", false);
 user_pref("media.navigator.streams.fake", true);
-user_pref("network.websocket.enabled", false);
+user_pref("network.websocket.enabled", true);
 user_pref("media.getusermedia.screensharing.enabled", false);
 user_pref("media.navigator.permission.disabled", true);
 user_pref("media.capture.mouse", false);
@@ -214,7 +214,7 @@ user_pref("toolkit.telemetry.sync.enabled", false);
 /****************************************************************************
  * SECTION: NEW HARDENING LINES                                             *
 ****************************************************************************/
-user_pref("privacy.firstparty.isolate", true); // [PRIVACY CONFIGURATION]
+user_pref("privacy.firstparty.isolate", false); // rely on modern partitioning for daily-use balance
 user_pref("security.tls.version.min", 3);      // [SECURITY]
 user_pref("security.tls.version.max", 4);      // [SECURITY]
 user_pref("signon.rememberSignons", true);         // [SECURITY]
@@ -225,7 +225,7 @@ user_pref("dom.push.enabled", false);              // [SECURITY]
 /****************************************************************************
  * SECTION: PRIVACY CONFIGURATION (isolation & partitioning)
 ****************************************************************************/
-user_pref("privacy.resistFingerprinting.letterboxing", false);          // keep RFP without visible margins
+user_pref("privacy.resistFingerprinting.letterboxing", false);          // keep disabled; daily-use profile avoids RFP overhead
 user_pref("privacy.partition.network_state", true);                     // partition caches, connections
 user_pref("privacy.partition.serviceWorkers", true);                    // partition SW scope/storage
 user_pref("privacy.partition.always_partition_third_party_non_cookie_storage", true); // partition more non-cookie storage
@@ -251,7 +251,7 @@ user_pref("network.IDN_show_punycode", true);                           // show 
 /****************************************************************************
  * SECTION: GFX / FINGERPRINTING
 ****************************************************************************/
-user_pref("webgl.disabled", true);                                      // reduce FP surface (breaks 3D/WebGL)
+user_pref("webgl.disabled", false);                                     // keep compatibility/perf for modern web apps
 user_pref("device.sensors.enabled", false);                              // disable motion/orientation sensors
 user_pref("dom.gamepad.enabled", false);                                 // gamepad FP off
 user_pref("dom.netinfo.enabled", false);                                 // hide network type/speed API


### PR DESCRIPTION
## Summary
- disable the heaviest daily-use hardening prefs that were causing noticeable lag and compatibility issues in modern web apps
- keep the privacy baseline focused on strict content blocking, fingerprinting protection, partitioning, containers, HTTPS-only mode, and denied-by-default permissions
- update the README to explain the new daily-use balance

## Changes
- set `privacy.resistFingerprinting = false`
- set `privacy.firstparty.isolate = false`
- set `network.websocket.enabled = true`
- set `webgl.disabled = false`
- document the profile as a privacy-focused but daily-usable baseline

## Why
The previous combination was too expensive for primary-browser use and was causing noticeable slowdown in sites such as ChatGPT. This change keeps meaningful privacy hardening while removing the prefs with the highest day-to-day compatibility and responsiveness cost.

## Privacy baseline preserved
- `browser.contentblocking.category = "strict"`
- `privacy.fingerprintingProtection = true`
- `privacy.partition.*` prefs kept enabled
- `network.cookie.cookieBehavior = 1`
- HTTPS-only mode
- blocked-by-default camera, microphone, geolocation, screen, notifications, and XR permissions
- telemetry and studies disabled
