### PR TITLE
firefox: second-round daily-use responsiveness adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ For that reason, the current baseline avoids some of the heaviest compatibility 
 - `privacy.firstparty.isolate` is disabled
 - `network.websocket.enabled` is enabled
 - `webgl.disabled` is disabled
+- `javascript.options.wasm.simd` is enabled
+- font visibility is permissive in normal/private/tracking-protection contexts and only strict under Resist Fingerprinting
 
 The remaining baseline still keeps:
 - strict content blocking

--- a/firefox/user.js
+++ b/firefox/user.js
@@ -7,7 +7,7 @@ user_pref("browser.sessionstore.interval", 60000);
 /****************************************************************************
  * SECTION: GFX                                                            *
 ****************************************************************************/
-user_pref("gfx.canvas.accelerated.cache-size", 1024);
+user_pref("gfx.canvas.accelerated.cache-size", 256);
 user_pref("gfx.content.skia-font-cache-size", 80);
 user_pref("browser.tabs.hoverPreview.enabled", false);
 user_pref("browser.tabs.hoverPreview.showThumbnails", false);
@@ -151,7 +151,7 @@ user_pref("network.cookie.cookieBehavior", 1);
 user_pref("privacy.trackingprotection.enabled", true);
 user_pref("privacy.resistFingerprinting", false);
 user_pref("geo.enabled", false);
-user_pref("javascript.options.wasm.simd", false);
+user_pref("javascript.options.wasm.simd", true);
 user_pref("media.autoplay.default", 1);
 user_pref("privacy.trackingprotection.pbmode.enabled", true);
 user_pref("privacy.socialtracking.block", true);
@@ -269,5 +269,8 @@ user_pref("beacon.enabled", false);                                      // bloc
 user_pref("dom.private-attribution.submission.enabled", false);
 user_pref("dom.private-attribution.reporting.enabled", false);
 
-user_pref("layout.css.font-visibility", 1);  // "base" fonts only
+user_pref("layout.css.font-visibility.standard", 3);                    // normal browsing can use user fonts
+user_pref("layout.css.font-visibility.trackingprotection", 3);          // keep normal rendering under ETP
+user_pref("layout.css.font-visibility.private", 3);                     // private browsing still usable
+user_pref("layout.css.font-visibility.resistFingerprinting", 1);        // keep strict font exposure only with RFP
 user_pref("security.ssl.require_safe_negotiation", true);


### PR DESCRIPTION
## Summary
- keep the privacy-focused daily-use baseline from the previous change
- restore a few modern web-app capabilities that still affect perceived responsiveness
- align a couple of graphics/rendering choices more closely with maintained daily-use Firefox tuning references

## Changes
- set `javascript.options.wasm.simd = true`
- change `gfx.canvas.accelerated.cache-size` from `1024` to `256`
- replace the global `layout.css.font-visibility = 1` override with granular values:
  - `layout.css.font-visibility.standard = 3`
  - `layout.css.font-visibility.trackingprotection = 3`
  - `layout.css.font-visibility.private = 3`
  - `layout.css.font-visibility.resistFingerprinting = 1`
- update the README to describe the second-round daily-use performance balance

## Why
The first rebalance removed the biggest compatibility and performance regressions. This follow-up keeps privacy-focused defaults intact while relaxing two additional areas that are common pain points for modern web apps:
- WebAssembly SIMD support
- overly restrictive font visibility during normal browsing

It also normalizes the canvas accelerated cache sizing toward a maintained daily-use Firefox tuning baseline.

## Privacy baseline preserved
- `browser.contentblocking.category = "strict"`
- `privacy.fingerprintingProtection = true`
- `privacy.partition.*` prefs kept enabled
- `network.cookie.cookieBehavior = 1`
- HTTPS-only mode
- blocked-by-default camera, microphone, geolocation, screen, notifications, and XR permissions
- telemetry and studies disabled
- Resist Fingerprinting still disabled for primary-profile compatibility

## References considered
- Mozilla support guidance for Resist Fingerprinting and Fingerprinting Protection
- arkenfox current direction on RFP/WebGL in the maintained template/release notes
- Betterfox daily-use baseline
- firefox-vanilla project notes referencing Betterfox/Fastfox as part of its performance-oriented approach
