### PR TITLE
fix: hyprpaper autostart + keep hyprland.lua as placeholder

### DIFF
--- a/hyprland/hyprland.conf
+++ b/hyprland/hyprland.conf
@@ -55,7 +55,12 @@ exec-once = waybar
 exec-once = swaync
 exec-once = betterbird
 exec-once = pypr
+exec-once = hyprpaper
 
+# hyprpaper.service (systemd --user) is enabled but its
+# ConditionEnvironment=WAYLAND_DISPLAY loses the race against the
+# compositor exporting that var at session start, so it never actually
+# launches hyprpaper — hence exec-once above instead of relying on it.
 # NVIDIA fan control: start via systemd user service (recommended)
 #   systemctl --user enable --now nvidia-fan.service
 # or manually: ~/Documents/config_files/services/nvidia/nvidiafan.sh

--- a/hyprland/hyprland.lua
+++ b/hyprland/hyprland.lua
@@ -1,0 +1,5 @@
+-- Hyprland auto-loads this file from the config dir; keep it present (even
+-- empty) so reload doesn't error. Autostart is handled by exec-once in
+-- hyprland.conf instead — the hyprland.start Lua event did not reliably
+-- fire on 0.56.0, which is what silently broke waybar/swaync/betterbird/pypr.
+return {}


### PR DESCRIPTION
## Summary
Follow-up to #44 (merged before its second commit landed — that commit is included here as the first commit of this branch).

- Restores `hyprland.lua` as an empty `return {}` placeholder instead of deleting it. Hyprland 0.56.0 auto-loads `hyprland.lua` from the config dir and logs a config error via `hyprctl configerrors` if it's missing, so outright deletion (what #44 shipped) isn't safe.
- Adds `exec-once = hyprpaper`. `hyprpaper.service` (systemd --user, enabled) never actually starts because its `ConditionEnvironment=WAYLAND_DISPLAY` loses the race against the compositor exporting that var — confirmed dead/no wallpaper on stc-desktop after reboot. exec-once already reliably starts the other 4 autostart apps the same way; do the same for hyprpaper instead of depending on the systemd unit's environment ordering.

## Test plan
- [x] Deployed to stc-desktop (`~/.config/hypr/hyprland.conf`, `hyprland.lua`), `hyprctl configerrors` clean
- [ ] Confirm wallpaper + waybar + swaync + betterbird + pypr all come up after a real reboot/login (exec-once only fires on session start, can't verify via `hyprctl reload`)