### PR TITLE
fix: remove dead render{explicit_sync} block

### DIFF
--- a/hyprland/hyprland.conf
+++ b/hyprland/hyprland.conf
@@ -191,14 +191,6 @@ misc {
     disable_hyprland_logo = false # If true disables the random hyprland logo / anime girl background. :(
 }
 
-# Hyprland 0.56.0 + nvidia-open-dkms 610.43.03 segfaults on hybrid NVIDIA/AMD
-# outputs inside commitPendingAndDoExplicitSync (aquamarine releaseStashedCommit).
-# Disabling explicit sync avoids the crash. Remove once upstream fixes it.
-render {
-    explicit_sync = false
-    explicit_sync_kms = false
-}
-
 
 #############
 ### INPUT ###


### PR DESCRIPTION
## Summary
- Removes the `render { explicit_sync = false; explicit_sync_kms = false }` block from `hyprland.conf`. These keys don't exist in the installed Hyprland (0.56.0) — `hyprctl configerrors` flags both, and Hyprland was showing that as an on-screen error overlay every session.

## Test plan
- [x] `hyprctl reload` after removing the block → `hyprctl configerrors` returns empty.